### PR TITLE
added signals to create a profile when a user is created

### DIFF
--- a/blog/apps.py
+++ b/blog/apps.py
@@ -4,3 +4,6 @@ from django.apps import AppConfig
 class BlogConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'blog'
+
+    def ready(self):
+        import blog.signals

--- a/blog/signals.py
+++ b/blog/signals.py
@@ -1,0 +1,15 @@
+from django.db.models.signals import post_save
+from django.contrib.auth import get_user_model
+from django.dispatch import receiver
+from .models import Profile
+
+User = get_user_model()
+
+@receiver(post_save, sender=User)
+def create_profile(sender, instance, created, **kwargs):
+    if created:
+        Profile.objects.create(user=instance)
+
+@receiver(post_save, sender=User)
+def save_profile(sender, instance, **kwargs):
+    instance.profile.save()


### PR DESCRIPTION
The issue was that when a user is created, a profile is not. Now with signals, the profile is automatically created when the user is.